### PR TITLE
chore: use pnpm instead of npm in package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   ],
   "scripts": {
     "clean": "rimraf --glob packages/*/dist",
-    "build": "npm run clean && npm run build --workspace=packages/core",
-    "test": "npm run build && npm run test --workspace=packages/core",
+    "build": "pnpm run clean && pnpm --filter @chonkiejs/core run build",
+    "test": "pnpm run build && pnpm --filter @chonkiejs/core run test",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "npm run build && changeset publish"
+    "release": "pnpm run build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
+    "build": "pnpm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
     "test": "vitest run"
   },
   "files": [

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
+    "build": "pnpm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
     "test": "echo 'No tests for @chonkiejs/token yet'"
   },
   "files": [


### PR DESCRIPTION
The monorepo uses pnpm workspaces and CI already invokes `pnpm --filter ... build` to publish, but several package.json scripts still called `npm run ...` and used npm's --workspace flag. Switch all script-internal invocations to pnpm for consistency.