### PR TITLE
Add prepublishOnly script to build dist before publishing

### DIFF
--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
+    "prepublishOnly": "npm run build",
     "test": "echo 'No tests for @chonkiejs/token yet'"
   },
   "files": [


### PR DESCRIPTION
This pull request fixes a bug in the package publishing workflow by ensuring the build process runs automatically before publishing. Currently dist for `token` doesn't end up in the published npm package. This PR should fix that.

- Build process automation:
  * Added a `prepublishOnly` script to `package.json` to automatically run the build before publishing the package.…publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package publication reliability by automating the build process to run automatically before each release, eliminating manual pre-publish build steps and ensuring consistent, properly compiled distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->