### PR TITLE
chore: patch publish workflow for existing package versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,14 @@ jobs:
         run: pnpm --filter @chonkiejs/core build
 
       - name: Publish to npm
-        run: pnpm --filter @chonkiejs/core exec npm publish --access public --provenance --no-git-checks
+        run: |
+          pnpm --filter @chonkiejs/core exec npm publish --access public --provenance --no-git-checks 2>&1 | tee /tmp/publish.log || {
+            if grep -q "previously published versions" /tmp/publish.log; then
+              echo "Version already exists, skipping."
+            else
+              exit 1
+            fi
+          }
 
   publish-token:
     name: Publish @chonkiejs/token
@@ -61,4 +68,11 @@ jobs:
         run: pnpm --filter @chonkiejs/token... build
 
       - name: Publish to npm
-        run: pnpm --filter @chonkiejs/token exec npm publish --access public --provenance --no-git-checks
+        run: |
+          pnpm --filter @chonkiejs/token exec npm publish --access public --provenance --no-git-checks 2>&1 | tee /tmp/publish.log || {
+            if grep -q "previously published versions" /tmp/publish.log; then
+              echo "Version already exists, skipping."
+            else
+              exit 1
+            fi
+          }


### PR DESCRIPTION
following https://github.com/chonkie-inc/chonkiejs/actions/runs/27786800893 
this pr patches workflows where a previous package version turns the entire publish workflow red 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved release process reliability by gracefully handling previously published package versions, preventing unnecessary deployment failures when encountering duplicate version attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->