### PR TITLE
chore: publish stable package for token

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsdown",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "test": "vitest run"
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsdown",
+    "prepublishOnly": "npm run build",
     "test": "vitest run"
   },
   "files": [

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chonkiejs/token",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "HuggingFace tokenizer support for Chonkie - extends @chonkiejs/core with real tokenization",
   "license": "MIT",
   "homepage": "https://docs.chonkie.ai",
@@ -23,6 +23,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
+    "prepublishOnly": "npm run build",
     "test": "echo 'No tests for @chonkiejs/token yet'"
   },
   "files": [

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc && tsc-alias -p tsconfig.json --resolve-full-paths",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "test": "echo 'No tests for @chonkiejs/token yet'"
   },
   "files": [


### PR DESCRIPTION
fixes #60 
This will ensure in case any future packages publish via the CLI will always build beforehand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automatic build step before packaging for core.
  * Added an automatic build step before packaging for the token package.
  * Bumped the token package version to **0.0.4**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->