### PR TITLE
chore: fix deprecation warning

### DIFF
--- a/packages/token/tsconfig.json
+++ b/packages/token/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ES2020",
+    "module": "ESNext",
     "lib": ["ES2021"],
     "moduleResolution": "bundler",
     "outDir": "./dist",

--- a/packages/token/tsconfig.json
+++ b/packages/token/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2021",
     "module": "ES2020",
     "lib": ["ES2021"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
without this `npm run build`  generates the following error
```
tsconfig.json:6:25 - error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
  Visit https://aka.ms/ts6 for migration information.

6     "moduleResolution": "node",
                          ~~~~~~
```
this pr switches to `"moduleResolution": "bundler"` following our implementation in @chonkiejs/core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript build configuration to align with modern bundler expectations by switching the module target to **ESNext** and using **bundler**-style module resolution.
  * Improves compatibility when packaging and integrating the token package in contemporary build pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->